### PR TITLE
Change PushNotificationSwitch to stateless function

### DIFF
--- a/app/components/DetectorConfig.jsx
+++ b/app/components/DetectorConfig.jsx
@@ -4,27 +4,24 @@ import { Card, CardTitle, CardText } from 'react-mdl/lib/Card';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 import Switch from 'react-mdl/lib/Switch';
 
-export default class DetectorConfig extends React.Component {
+export default function DetectorConfig(props) {
+  if (_.isEmpty(props.detector)) { return null; }
 
-  render() {
-    if (_.isEmpty(this.props.detector)) { return null; }
+  const { name, isRunning } = props.detector;
 
-    const { name, isRunning } = this.props.detector;
-
-    return (
-      <Card shadow={2}>
-        <CardTitle>{name}</CardTitle>
-        <CardText>
-          <Grid>
-            <Cell col={3} />
-            <Cell col={3}>
-              <Switch disabled ripple checked={isRunning}>Status</Switch>
-            </Cell>
-          </Grid>
-        </CardText>
-      </Card>
-    );
-  }
+  return (
+    <Card shadow={2}>
+      <CardTitle>{name}</CardTitle>
+      <CardText>
+        <Grid>
+          <Cell col={3} />
+          <Cell col={3}>
+            <Switch disabled ripple checked={isRunning}>Status</Switch>
+          </Cell>
+        </Grid>
+      </CardText>
+    </Card>
+  );
 }
 
 DetectorConfig.propTypes = {

--- a/app/components/DeviceConnectionStatus.jsx
+++ b/app/components/DeviceConnectionStatus.jsx
@@ -1,13 +1,11 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 
-export default class DeviceConnectionStatus extends Component {
-  render() {
-    const { online } = this.props;
+export default function DeviceConnectionStatus(props) {
+  const { online } = props;
 
-    return (
-      <h6>Device is {online ? 'online' : 'offline'}</h6>
-    );
-  }
+  return (
+    <h6>Device is {online ? 'online' : 'offline'}</h6>
+  );
 }
 
 DeviceConnectionStatus.propTypes = {

--- a/app/components/IncidentListItem.jsx
+++ b/app/components/IncidentListItem.jsx
@@ -1,30 +1,28 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import { ListItemContent } from 'react-mdl/lib/List';
 import moment from 'moment';
 
-export default class IncidentListItem extends Component {
-  icon(code) {
-    switch (code) {
-      case 'motion_started':
-      case 'noise_started':
-        return 'alarm';
-      case 'motion_stopped':
-      case 'noise_stopped':
-        return 'alarm_off';
-      default:
-        return null;
-    }
+function icon(code) {
+  switch (code) {
+    case 'motion_started':
+    case 'noise_started':
+      return 'alarm';
+    case 'motion_stopped':
+    case 'noise_stopped':
+      return 'alarm_off';
+    default:
+      return null;
   }
+}
 
-  render() {
-    const { incident } = this.props;
+export default function IncidentListItem(props) {
+  const { incident } = props;
 
-    return (
-      <ListItemContent subtitle={incident.message} icon={this.icon(incident.code)}>
-        {moment(incident.triggeredAt).format('HH:mm:ss')}
-      </ListItemContent>
-    );
-  }
+  return (
+    <ListItemContent subtitle={incident.message} icon={icon(incident.code)}>
+      {moment(incident.triggeredAt).format('HH:mm:ss')}
+    </ListItemContent>
+  );
 }
 
 IncidentListItem.propTypes = {

--- a/app/components/PushNotificationSwitch.jsx
+++ b/app/components/PushNotificationSwitch.jsx
@@ -1,32 +1,30 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import Grid, { Cell } from 'react-mdl/lib/Grid';
 import Switch from 'react-mdl/lib/Switch';
 
-export default class PushNotificationSwitch extends Component {
-  render() {
-    const { checked, disabled, onChange } = this.props;
+export default function PushNotificationSwitch(props) {
+  const { checked, disabled, onChange } = props;
 
-    return (
-      <Grid>
-        <Cell col={10}>
-          <label htmlFor="toggle-push-notifications">
-            <span className="mdl-switch__label">
-              Enable push notifications
-            </span>
-          </label>
-        </Cell>
-        <Cell col={2}>
-          <Switch ripple
-            checked={checked}
-            disabled={disabled}
-            onChange={onChange}
-            className="btn btn-success"
-            id="toggle-push-notifications"
-          />
-        </Cell>
-      </Grid>
-    );
-  }
+  return (
+    <Grid>
+      <Cell col={10}>
+        <label htmlFor="toggle-push-notifications">
+          <span className="mdl-switch__label">
+            Enable push notifications
+          </span>
+        </label>
+      </Cell>
+      <Cell col={2}>
+        <Switch ripple
+          checked={checked}
+          disabled={disabled}
+          onChange={onChange}
+          className="btn btn-success"
+          id="toggle-push-notifications"
+        />
+      </Cell>
+    </Grid>
+  );
 }
 
 PushNotificationSwitch.propTypes = {

--- a/app/components/User.jsx
+++ b/app/components/User.jsx
@@ -1,24 +1,22 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import Constants from '../constants';
 
-export default class User extends Component {
-  render() {
-    const { auth } = this.props;
+export default function User(props) {
+  const { auth } = props;
 
-    if (auth.state !== Constants.AUTH_SIGNED_IN) {
-      return null;
-    }
-
-    return (
-      <div className="user">
-        <img
-          className="user__avatar"
-          src={auth.avatarUrl}
-        />
-        <h6>{auth.email}</h6>
-      </div>
-    );
+  if (auth.state !== Constants.AUTH_SIGNED_IN) {
+    return null;
   }
+
+  return (
+    <div className="user">
+      <img
+        className="user__avatar"
+        src={auth.avatarUrl}
+      />
+      <h6>{auth.email}</h6>
+    </div>
+  );
 }
 
 User.propTypes = {


### PR DESCRIPTION
@szimek We just started receiving from linter few errors related to using Component inheritance for simple display operation (https://facebook.github.io/react/docs/reusable-components.html#stateless-functions)

```
ERROR in ./app/components/DetectorConfig.jsx

/Users/jacekrzeszutek/Documents/Code/watchdog/app/components/DetectorConfig.jsx
  7:16  error  Component should be written as a pure function  react/prefer-stateless-function

✖ 1 problem (1 error, 0 warnings)


ERROR in ./app/components/IncidentListItem.jsx

/Users/jacekrzeszutek/Documents/Code/watchdog/app/components/IncidentListItem.jsx
  5:16  error  Component should be written as a pure function  react/prefer-stateless-function

✖ 1 problem (1 error, 0 warnings)
```

Switching to them in those places, would give us:
- small performance optimizations (not sure whether now or in the future, because React's optimizations related to this are still evolving)
- enforcing of stateless, simple design for dumb components

Drawbacks:
- "do not have internal state, do not have backing instances, and do not have the component lifecycle methods" ...if it will be needed in the future.

Not sure whether all components mentioned by linter will be so simple in the future. But still, switching back to inheritance from `Component` in certain components should be quick (if needed).

So, shall we go for stateless functions in:
`PushNotificationSwitch` (done)
+
`LandingPage`,
`LayoutContainer`,
`User`,
`IndcidentList`,
`DeviceConnectionStatus`,
`DetectorConfig`,
`IncidentListItem` 
? :)

If so, I'll just add them to this PR


