### PR TITLE
Fix requireAuth to check authentication only after sign in has finished

### DIFF
--- a/app/routes.jsx
+++ b/app/routes.jsx
@@ -37,26 +37,31 @@ export default function routes(store) {
     </Route>
   );
 
-  function requireAuth(nextState, replace) {
-    console.log('requireAuth');
+  function requireAuth(nextState, replace, callback) {
     const url = nextState.location.pathname;
 
-    if (!firebase.auth().currentUser) {
-      replace({
-        pathname: '/',
-        query: { 'return-to': encodeURIComponent(url) },
-        state: { nextPathname: url },
-      });
-    }
+    firebase.auth().onAuthStateChanged((user) => {
+      if (!user) {
+        replace({
+          pathname: '/',
+          query: { 'return-to': encodeURIComponent(url) },
+          state: { nextPathname: url },
+        });
+      }
+      callback();
+    });
   }
 
-  function requireNoAuth(nextState, replace) {
-    if (firebase.auth().currentUser) {
-      replace({
-        pathname: '/devices',
-        state: { nextPathname: nextState.location.pathname },
-      });
-    }
+  function requireNoAuth(nextState, replace, callback) {
+    firebase.auth().onAuthStateChanged((user) => {
+      if (user) {
+        replace({
+          pathname: '/devices',
+          state: { nextPathname: nextState.location.pathname },
+        });
+      }
+      callback();
+    });
   }
 
   function fetchDevice(nextState, replace, callback) {

--- a/app/routes.jsx
+++ b/app/routes.jsx
@@ -40,7 +40,9 @@ export default function routes(store) {
   function requireAuth(nextState, replace, callback) {
     const url = nextState.location.pathname;
 
-    firebase.auth().onAuthStateChanged((user) => {
+    const unsubscribe = firebase.auth().onAuthStateChanged((user) => {
+      unsubscribe();
+
       if (!user) {
         replace({
           pathname: '/',
@@ -53,7 +55,9 @@ export default function routes(store) {
   }
 
   function requireNoAuth(nextState, replace, callback) {
-    firebase.auth().onAuthStateChanged((user) => {
+    const unsubscribe = firebase.auth().onAuthStateChanged((user) => {
+      unsubscribe();
+
       if (user) {
         replace({
           pathname: '/devices',


### PR DESCRIPTION
Because of insufficient requireAuth (allowing user with pending sign in to pass), device list was sometimes not properly loading just after signing in.